### PR TITLE
修复若移除kjs_te后导致的交易站配方失效，移除暮色工作台配方

### DIFF
--- a/overrides/kubejs/server_scripts/recipes/tweaks/general_tweaks.js
+++ b/overrides/kubejs/server_scripts/recipes/tweaks/general_tweaks.js
@@ -1187,7 +1187,7 @@ event.shaped(('buddycards:luminis_sleeve'), [
       event.custom({
         type: 'thermal:press',
         ingredients: [
-          Ingredient.of(ingredient).toJson(),
+          Item.of(ingredient).toResultJson(),
           Ingredient.of(card_id).toJson(),
         ],
         result: [
@@ -1546,8 +1546,6 @@ function prettierpipes(event) {
       event.recipes.createSplashing([Item.of(nugget, 2)], dust)
       event.recipes.createMixing([Fluid.of(fluid, 540)], [Item.of(dust, 1), AE2('matter_ball')]).superheated()
   
-      event.remove({"input": [{"tag": "forge:ores/" + name}], "type": "create:milling"})
-      event.remove({"input": [{"tag": "forge:ores/" + name}], "type": "create:crushing"})
       event.remove({id: `thermal:machines/pulverizer/pulverizer_${name}_ore`})
       event.remove({id: `thermal:machines/smelter/smelter_${name}_ore`})
 //      event.remove({ input: "#forge:ores/" + name, type: TE("smelter") })
@@ -1662,8 +1660,6 @@ function prettierpipes(event) {
     "experience": 0.2,
     "energy": 20000
     })
-
-
 }
   
     dust_process2('cobalt', 'tconstruct:cobalt_ingot', 'tconstruct:cobalt_nugget', 'kubejs:cobalt_dust', 'tconstruct:cobalt_ore', TE('sulfur'), 'lead')
@@ -1774,5 +1770,7 @@ function prettierpipes(event) {
     "result": [{"item": "minecraft:redstone","count": 8}],
     "energy": 10000
   })
+ 
+    event.remove({ id: 'twilightforest:uncrafting_table' })
   
   })

--- a/overrides/kubejs/server_scripts/recipes/tweaks/ore_processing.js
+++ b/overrides/kubejs/server_scripts/recipes/tweaks/ore_processing.js
@@ -90,6 +90,8 @@ onEvent("recipes", event => {
 
 })
 
+let colours = ['white', 'orange', 'magenta', 'light_blue', 'lime', 'pink', 'purple', 'light_gray', 'gray', 'cyan', 'brown', 'green', 'blue', 'red', 'black', 'yellow']
+
 onEvent('item.tags', event => {
 
   global.trades.forEach(element => {
@@ -100,6 +102,9 @@ onEvent('item.tags', event => {
 		event.get('forge:profession_cards').add(`kubejs:profession_card_${element}`)
 	});
 
+	colours.forEach(element => {
+		event.get(C('glazed_terracotta')).add(MC(`${element}_glazed_terracotta`))
+	});
 
   event.get('forge:raw_materials').add('kubejs:raw_stormyx')
   event.get('forge:raw_materials/stormyx').add('kubejs:raw_stormyx')


### PR DESCRIPTION
修复若移除kjs_te后导致的交易站配方失效，但有个bug，在服务端会有一个空配方，移除暮色工作台配方列表。
归根结底还是得找到为啥kjs_te会导致无法加入服务器，就不用头疼了